### PR TITLE
Remove the certificate checking defaults used by LWP::UserAgent

### DIFF
--- a/DotDotPwn/HTTP_Url.pm
+++ b/DotDotPwn/HTTP_Url.pm
@@ -46,6 +46,8 @@ sub FuzzHTTP_Url{
 		$UserAgent = @UserAgents[int(rand(@UserAgents))];
 		$UserAgent =~ s/[\r\n]//g;
 		$http->agent($UserAgent);
+		$http->ssl_opts(verify_hostname => 0);
+		$http->ssl_opts(SSL_verify_mode => 0x00);
 
 		my $tmp_url = $url; # Not to overwrite the TRAVERSAL token
 		$tmp_url =~ s/TRAVERSAL/$traversal/g;


### PR DESCRIPTION
When using this tool through proxychains to then proxy through an upstream content inspection proxy such as BurpSuite, the tool fails to validate the certificate and as a result does not work.  As this tool is not designed for user security, the strict certificate checking defaults seem irrelevant and so have been disabled.